### PR TITLE
Fix #13: tolerate non-improving alpha-expansion moves instead of crashing

### DIFF
--- a/src/samesh/models/shape_diameter_function.py
+++ b/src/samesh/models/shape_diameter_function.py
@@ -110,6 +110,11 @@ def repartition(
 
     cost_smoothness = cost_smoothness * _lambda
 
+    # st_mincut requires non-negative capacities; the smoothness term
+    # -log(angle / pi + EPSILON) dips marginally below zero when an adjacency
+    # angle reaches pi, so clamp to guard the invariant (no-op on typical data).
+    cost_smoothness = np.clip(cost_smoothness, 0.0, None)
+
     # networkx broken for float capacities
     #cost_data       = np.round(cost_data       * SCALE).astype(int)
     #cost_smoothness = np.round(cost_smoothness * SCALE).astype(int)
@@ -140,12 +145,23 @@ def repartition(
             T = np.array([index2node[v] for v in T if isinstance(index2node[v], int)]).astype(int)
 
             assert (partition[S] == label).sum() == 0 # T consists of those assigned 'alpha' and S 'alpha_complement' (see paper)
-            partition[T] = label
 
+            # Tentatively apply the alpha-expansion move, then accept it only if it
+            # does not increase the energy. In exact arithmetic the cut is optimal
+            # so cost cannot rise, but with floating-point capacities (and the
+            # degenerate/duplicate adjacencies that show up on imperfect meshes)
+            # the recomputed cost can rise by a tiny amount. Rather than aborting
+            # the whole segmentation (issue #13), reject non-improving moves and
+            # continue. On meshes where every move strictly improves cost, this is
+            # bit-equivalent to the previous behaviour.
+            previous = partition[T].copy()
+            partition[T] = label
             cost = partition_cost(mesh, partition, cost_data, cost_smoothness)
-            if cost > cost_min:
-                raise ValueError('Cost increased. This should not happen because the graph cut is optimal.')
-            cost_min = cost
+            tolerance = 1e-9 * (abs(cost_min) + 1.0)
+            if cost > cost_min + tolerance:
+                partition[T] = previous  # revert: keep the better partition
+            else:
+                cost_min = min(cost_min, cost)
     
     return partition
 

--- a/test_repartition.py
+++ b/test_repartition.py
@@ -1,0 +1,185 @@
+"""
+Tests for the alpha-expansion graph-cut repartition (issue #13).
+
+The previous implementation aborted the entire segmentation with
+`raise ValueError('Cost increased. ...')` whenever the recomputed
+energy of an alpha-expansion move exceeded the previous best by any
+amount, including a floating-point epsilon. The patched version
+accepts only moves that decrease energy (within a small tolerance)
+and reverts the rest, matching the standard alpha-expansion algorithm
+and degrading gracefully on imperfect meshes.
+
+Run with: PYTHONPATH=src python test_repartition.py
+Requires the same heavy deps as samesh.models.shape_diameter_function
+(igraph, pymeshlab, sklearn, omegaconf, tqdm); the suite skips with a
+clear message if any are missing so the lightweight test_fixes.py
+runner is not affected.
+"""
+from __future__ import annotations
+
+import sys
+import traceback
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+try:
+    import numpy as np
+    import trimesh
+    from samesh.models import shape_diameter_function as sdf_mod
+    from samesh.models.shape_diameter_function import (
+        repartition,
+        partition_cost,
+    )
+except Exception as exc:  # pragma: no cover - exercised only when deps missing
+    print(f"SKIP test_repartition: missing dependency ({exc.__class__.__name__}: {exc})")
+    sys.exit(0)
+
+
+EPSILON = 1e-20
+
+
+def _sphere_inputs(seed: int = 0, K: int = 3):
+    mesh = trimesh.creation.icosphere(subdivisions=2)
+    F = len(mesh.faces)
+    rng = np.random.RandomState(seed)
+    logits = rng.randn(F, K) * 2.0
+    probs = np.exp(logits - logits.max(axis=1, keepdims=True))
+    probs = probs / probs.sum(axis=1, keepdims=True)
+    cost_data = -np.log(probs + EPSILON)
+    cost_smoothness = -np.log(mesh.face_adjacency_angles / np.pi + EPSILON)
+    partition = np.argmin(cost_data, axis=1)
+    return mesh, partition, cost_data, cost_smoothness
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_repartition_smoke_runs_and_returns_valid_labels():
+    """End-to-end: repartition runs on a real mesh and returns a per-face label
+    array drawn only from the labels present in the initial partition."""
+    mesh, partition, cost_data, cost_smoothness = _sphere_inputs(seed=0, K=3)
+    initial_labels = set(np.unique(partition).tolist())
+    out = repartition(
+        mesh, partition.copy(), cost_data, cost_smoothness,
+        smoothing_iterations=2, _lambda=1.0,
+    )
+    assert out.shape == partition.shape
+    assert set(np.unique(out).tolist()).issubset(initial_labels)
+
+
+def test_repartition_rejects_non_improving_move_instead_of_raising():
+    """Force partition_cost to report a cost increase after the very first move.
+    The patched code must NOT raise; it must reject the move and return a valid
+    partition. (The pre-fix code raised ValueError unconditionally.)"""
+    mesh, partition, cost_data, cost_smoothness = _sphere_inputs(seed=1, K=3)
+
+    original = sdf_mod.partition_cost
+    state = {"calls": 0}
+
+    def increasing_partition_cost(*args, **kwargs):
+        # 1st call: baseline cost_min before the loop (compute honestly).
+        # Subsequent calls: report a value much larger than the baseline so the
+        # patched guard rejects every move. The original code raised here.
+        state["calls"] += 1
+        if state["calls"] == 1:
+            baseline = float(original(*args, **kwargs))
+            state["baseline"] = baseline
+            return baseline
+        return state["baseline"] + 1e6  # well outside the tolerance window
+
+    sdf_mod.partition_cost = increasing_partition_cost
+    try:
+        out = repartition(
+            mesh, partition.copy(), cost_data, cost_smoothness,
+            smoothing_iterations=1, _lambda=1.0,
+        )
+    finally:
+        sdf_mod.partition_cost = original
+
+    # All moves rejected => partition is unchanged, no exception raised.
+    assert out.shape == partition.shape
+    assert np.array_equal(out, partition), "rejected moves should leave the partition untouched"
+
+
+def test_repartition_accepts_tiny_floating_point_increase():
+    """Patched code must tolerate a sub-epsilon FP overshoot of cost_min
+    (the exact symptom of issue #13) and continue rather than crash."""
+    mesh, partition, cost_data, cost_smoothness = _sphere_inputs(seed=2, K=3)
+
+    original = sdf_mod.partition_cost
+    state = {"calls": 0, "baseline": None}
+
+    def jitter_partition_cost(*args, **kwargs):
+        state["calls"] += 1
+        if state["calls"] == 1:
+            state["baseline"] = float(original(*args, **kwargs))
+            return state["baseline"]
+        # Always report cost_min + a tiny epsilon: theoretically optimal but
+        # numerically above cost_min. Pre-fix code raised; patched code
+        # accepts within tolerance.
+        return state["baseline"] + 1e-12
+
+    sdf_mod.partition_cost = jitter_partition_cost
+    try:
+        out = repartition(
+            mesh, partition.copy(), cost_data, cost_smoothness,
+            smoothing_iterations=1, _lambda=1.0,
+        )
+    finally:
+        sdf_mod.partition_cost = original
+
+    assert out.shape == partition.shape  # completed without raising
+
+
+def test_repartition_clamps_negative_smoothness_costs():
+    """Smoothness term -log(angle/pi + eps) dips slightly negative at angle=pi.
+    Negative capacities violate the min-cut precondition; repartition must
+    handle them without raising."""
+    mesh, partition, cost_data, _ = _sphere_inputs(seed=3, K=3)
+    E = len(mesh.face_adjacency)
+    cost_smoothness = np.full(E, -1e-20)  # uniformly tiny-negative
+    out = repartition(
+        mesh, partition.copy(), cost_data, cost_smoothness,
+        smoothing_iterations=1, _lambda=1.0,
+    )
+    assert out.shape == partition.shape
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+TESTS = [
+    test_repartition_smoke_runs_and_returns_valid_labels,
+    test_repartition_rejects_non_improving_move_instead_of_raising,
+    test_repartition_accepts_tiny_floating_point_increase,
+    test_repartition_clamps_negative_smoothness_costs,
+]
+
+
+def main() -> int:
+    passed = 0
+    failed = []
+    for fn in TESTS:
+        try:
+            fn()
+        except Exception:
+            failed.append((fn.__name__, traceback.format_exc()))
+            print(f"FAIL  {fn.__name__}")
+        else:
+            passed += 1
+            print(f"PASS  {fn.__name__}")
+
+    print(f"\n{passed}/{len(TESTS)} tests passed")
+    for name, tb in failed:
+        print(f"\n--- {name} ---\n{tb}")
+    return 0 if not failed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes #13.

## What

`repartition()` in `shape_diameter_function.py` ran an alpha-expansion graph cut and, after each move, recomputed the partition energy and raised:

> `ValueError: Cost increased. This should not happen because the graph cut is optimal.`

…whenever the recomputed value exceeded the previous best by *any* amount, using an exact float `>` comparison. In exact arithmetic the invariant holds, but the graph capacities here are floats (data costs `-log(prob + 1e-20)` span up to ~46; smoothness costs span a similar range; t-links use `float('inf')`), so the recomputed cost can rise by a tiny epsilon — from re-summation order, from a marginally-suboptimal float min-cut, or from energy/graph divergence on imperfect meshes with duplicate/degenerate face adjacencies. The result is that the whole segmentation aborts on certain user meshes (as in #13).

The hard guard also disagrees with the standard alpha-expansion algorithm: a move is meant to be *accepted* only if it strictly decreases the energy; otherwise it is rejected and the loop continues. The pre-fix code applied every move unconditionally and then crashed if it turned out to be non-improving.

## Change

- Tentatively apply the candidate move, recompute the energy, and accept it only if `cost <= cost_min + tol`. Otherwise revert `partition[T]` to its previous labels and continue. `tol = 1e-9 * (|cost_min| + 1)` — large enough to absorb FP jitter, small enough to still reject genuine regressions.
- Clamp `cost_smoothness` to be non-negative after the `_lambda` multiply. `-log(angle/pi + eps)` is marginally negative when an adjacency angle reaches π, and `igraph.Graph.st_mincut` assumes non-negative capacities. On typical inputs the clamp is a no-op.

On meshes where every alpha-expansion move strictly improves cost (i.e. anything that ran cleanly before), the new path is bit-equivalent to the old one: `cost <= cost_min + tol` is true, the move is accepted, `cost_min` is updated to the new value, the partition matches.

## Tests

New `test_repartition.py` with four tests, including a deterministic monkeypatch that forces `partition_cost` to report a cost increase and verifies the patched code rejects the move instead of raising. Confirmed the same test raises `ValueError` on the pre-fix code, so it is genuinely guarding against the regression.

```
PASS  test_repartition_smoke_runs_and_returns_valid_labels
PASS  test_repartition_rejects_non_improving_move_instead_of_raising
PASS  test_repartition_accepts_tiny_floating_point_increase
PASS  test_repartition_clamps_negative_smoothness_costs

4/4 tests passed
```

The existing `test_fixes.py` suite from #20 still passes (10/10).

## Notes

- I did not synthetically reproduce the exact numeric trigger from #13 — extensive sweeps on icosphere/strip meshes with realistic `-log(prob+eps)` cost ranges did not fire it, so the bug is sensitive to specific mesh topology (likely degenerate adjacencies in the reporter's own model, consistent with the maintainer's earlier suspicion that the rendering/input was the underlying cause). The fix is robust to all plausible mechanisms because it stops trusting an exact float invariant and instead enforces the algorithmically correct accept/reject rule.
- This does not address the upstream cause of any bad input (e.g. degenerate renderings producing weird `cost_data`); it only stops one symptom — the whole-pipeline crash — and lets users get a valid local-optimum segmentation on more meshes.
